### PR TITLE
Fix extension build 'export' error on Windows

### DIFF
--- a/packages/epub-press-chrome/package.json
+++ b/packages/epub-press-chrome/package.json
@@ -32,6 +32,7 @@
         "@babel/runtime": "^7.10.2",
         "babel-loader": "^8.1.0",
         "chai": "^4.2.0",
+        "cross-env": "^7.0.3",
         "fetch-mock": "^5.1.1",
         "mocha": "^6.2.3",
         "mocha-loader": "^2.0.1",

--- a/packages/epub-press-chrome/package.json
+++ b/packages/epub-press-chrome/package.json
@@ -3,11 +3,11 @@
     "main": "index.js",
     "private": true,
     "scripts": {
-        "test": "export ENV=test && open http://localhost:5001/tests && webpack-dev-server",
-        "build": "export ENV=development && webpack",
+        "test": "cross-env ENV=test && open http://localhost:5001/tests && webpack-dev-server",
+        "build": "cross-env ENV=development && webpack",
         "webpackVer": "webpack --version",
-        "build-prod": "export NODE_ENV=production && webpack",
-        "start": "export ENV=development && webpack --watch --color --progress"
+        "build-prod": "cross-env NODE_ENV=production && webpack",
+        "start": "cross-env ENV=development && webpack --watch --color --progress"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
`export` doesn't seem to work on Windows, so I've replaced it with a `cross-env` npm package that provides the same functionality in a cross-platform manner