### PR TITLE
feat(epub-press-chrome): migrate to Manifest V3

### DIFF
--- a/packages/epub-press-chrome/app/manifest.json
+++ b/packages/epub-press-chrome/app/manifest.json
@@ -4,7 +4,7 @@
     "version": "0.12.1",
     "author": "Harold Treen",
     "homepage_url": "https://epub.press/",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "description": "__MSG_appDescription__",
     "icons": {
         "16": "images/download-icon-16.png",
@@ -12,18 +12,19 @@
     },
     "default_locale": "en",
     "background": {
-        "scripts": [
-            "build/background.js"
-        ]
+        "service_worker": "build/background.js"
     },
     "permissions": [
         "tabs",
         "downloads",
         "storage",
-        "http://*/",
-        "https://*/"
+        "scripting"
     ],
-    "browser_action": {
+    "host_permissions": [
+        "http://*/*",
+        "https://*/*"
+    ],
+    "action": {
         "default_icon": {
             "20": "images/download-icon-20.png",
             "32": "images/download-icon-32.png"

--- a/packages/epub-press-chrome/scripts/browser.js
+++ b/packages/epub-press-chrome/scripts/browser.js
@@ -24,11 +24,11 @@ class Browser {
     }
 
     static isBackgroundMsg(sender) {
-        return sender.url.indexOf('popup') < 0;
+        return !sender.url || sender.url.indexOf('popup') < 0;
     }
 
     static isPopupMsg(sender) {
-        return sender.url.indexOf('popup') > -1;
+        return sender.url && sender.url.indexOf('popup') > -1;
     }
 
     static getCurrentWindowTabs() {
@@ -53,18 +53,22 @@ class Browser {
     }
 
     static getTabsHtml(tabs) {
-        const code = 'document.documentElement.outerHTML';
+        const func = () => document.documentElement.outerHTML;
         const htmlPromises = tabs.map(
             tab => new Promise((resolve) => {
-                chrome.tabs.executeScript(tab.id, { code }, (html) => {
-                    const updatedTab = tab;
-                    if (html && html[0] && html[0].match(/html/i)) {
-                        updatedTab.html = html[0];
-                    } else {
-                        updatedTab.html = null;
+                chrome.scripting.executeScript(
+                    { target: { tabId: tab.id }, func },
+                    (results) => {
+                        const updatedTab = tab;
+                        const html = results && results[0] && results[0].result;
+                        if (html && html.match(/html/i)) {
+                            updatedTab.html = html;
+                        } else {
+                            updatedTab.html = null;
+                        }
+                        resolve(updatedTab);
                     }
-                    resolve(updatedTab);
-                });
+                );
             }),
         );
 


### PR DESCRIPTION
## Summary

- Updates `app/manifest.json` from Manifest V2 to V3 (required to publish on Chrome Web Store)
- Migrates `background.scripts` → `background.service_worker`
- Renames `browser_action` → `action`
- Moves `http://*/` and `https://*/` out of `permissions` into `host_permissions`
- Adds `scripting` to `permissions`
- Updates `browser.js` to use `chrome.scripting.executeScript` (replaces removed `chrome.tabs.executeScript`)
- Guards `sender.url` in `isBackgroundMsg`/`isPopupMsg` — service workers have no URL and `sender.url` is `undefined` in MV3

## Test plan

- [ ] `cd packages/epub-press-chrome && npm run build` — build completes without errors
- [ ] Load unpacked extension from `app/` in `chrome://extensions` — no manifest errors shown
- [ ] Extension popup opens and tab list populates correctly
- [ ] Download flow completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)