### PR TITLE
chore(epub-press-chrome): update changelog, build artifacts, and package-lock for 0.13.0

### DIFF
--- a/packages/epub-press-chrome/CHANGELOG.md
+++ b/packages/epub-press-chrome/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.13.0
+
+-   Updated to Manifest V3
+
 ### 0.12.1
 
 -   Unminified to simplify extension store review process.

--- a/packages/epub-press-chrome/app/build/background.js
+++ b/packages/epub-press-chrome/app/build/background.js
@@ -116,11 +116,11 @@ class Browser {
   }
 
   static isBackgroundMsg(sender) {
-    return sender.url.indexOf('popup') < 0;
+    return !sender.url || sender.url.indexOf('popup') < 0;
   }
 
   static isPopupMsg(sender) {
-    return sender.url.indexOf('popup') > -1;
+    return sender.url && sender.url.indexOf('popup') > -1;
   }
 
   static getCurrentWindowTabs() {
@@ -149,15 +149,20 @@ class Browser {
   }
 
   static getTabsHtml(tabs) {
-    const code = 'document.documentElement.outerHTML';
-    const htmlPromises = tabs.map(tab => new bluebird__WEBPACK_IMPORTED_MODULE_0___default.a(resolve => {
-      chrome.tabs.executeScript(tab.id, {
-        code
-      }, html => {
-        const updatedTab = tab;
+    const func = () => document.documentElement.outerHTML;
 
-        if (html && html[0] && html[0].match(/html/i)) {
-          updatedTab.html = html[0];
+    const htmlPromises = tabs.map(tab => new bluebird__WEBPACK_IMPORTED_MODULE_0___default.a(resolve => {
+      chrome.scripting.executeScript({
+        target: {
+          tabId: tab.id
+        },
+        func
+      }, results => {
+        const updatedTab = tab;
+        const html = results && results[0] && results[0].result;
+
+        if (html && html.match(/html/i)) {
+          updatedTab.html = html;
         } else {
           updatedTab.html = null;
         }

--- a/packages/epub-press-chrome/app/build/popup.js
+++ b/packages/epub-press-chrome/app/build/popup.js
@@ -116,11 +116,11 @@ class Browser {
   }
 
   static isBackgroundMsg(sender) {
-    return sender.url.indexOf('popup') < 0;
+    return !sender.url || sender.url.indexOf('popup') < 0;
   }
 
   static isPopupMsg(sender) {
-    return sender.url.indexOf('popup') > -1;
+    return sender.url && sender.url.indexOf('popup') > -1;
   }
 
   static getCurrentWindowTabs() {
@@ -149,15 +149,20 @@ class Browser {
   }
 
   static getTabsHtml(tabs) {
-    const code = 'document.documentElement.outerHTML';
-    const htmlPromises = tabs.map(tab => new bluebird__WEBPACK_IMPORTED_MODULE_0___default.a(resolve => {
-      chrome.tabs.executeScript(tab.id, {
-        code
-      }, html => {
-        const updatedTab = tab;
+    const func = () => document.documentElement.outerHTML;
 
-        if (html && html[0] && html[0].match(/html/i)) {
-          updatedTab.html = html[0];
+    const htmlPromises = tabs.map(tab => new bluebird__WEBPACK_IMPORTED_MODULE_0___default.a(resolve => {
+      chrome.scripting.executeScript({
+        target: {
+          tabId: tab.id
+        },
+        func
+      }, results => {
+        const updatedTab = tab;
+        const html = results && results[0] && results[0].result;
+
+        if (html && html.match(/html/i)) {
+          updatedTab.html = html;
         } else {
           updatedTab.html = null;
         }

--- a/packages/epub-press-chrome/package-lock.json
+++ b/packages/epub-press-chrome/package-lock.json
@@ -2410,6 +2410,58 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.1"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "7.0.6",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+                    "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",


### PR DESCRIPTION
## Summary

- Adds 0.13.0 entry to `CHANGELOG.md` noting the MV3 upgrade
- Commits rebuilt `app/build/background.js` and `app/build/popup.js` from the production build
- Commits `package-lock.json` with `cross-env` added (was missing from `node_modules`, causing `build-prod` to fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)