### PR TITLE
Keep service worker alive for the whole publish (fix stall on long steps)

### DIFF
--- a/packages/epub-press-chrome/CHANGELOG.md
+++ b/packages/epub-press-chrome/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.13.2
+
+-   Fix publishing stalling on long steps (e.g. "Fetching Images") by keeping the service worker alive for the whole publish, even when the popup is closed.
+-   Ignore the expected "Receiving end does not exist" rejection when the background messages a closed popup.
+
 ### 0.13.1
 
 -   Fix service worker crashing on load under Manifest V3 (`file-saver` touches `document` at import time, which is unavailable in a service worker).

--- a/packages/epub-press-chrome/app/build/background.js
+++ b/packages/epub-press-chrome/app/build/background.js
@@ -192,7 +192,15 @@ class Browser {
   }
 
   static sendMessage(...args) {
-    chrome.runtime.sendMessage(...args);
+    // In MV3 sendMessage returns a promise that rejects with "Receiving
+    // end does not exist" when no popup is open. These are best-effort UI
+    // updates (the popup restores state from storage on reopen), so the
+    // rejection is expected and safe to ignore.
+    const result = chrome.runtime.sendMessage(...args);
+
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
   }
 
   static onBackgroundMessage(cb) {
@@ -219,6 +227,28 @@ class Browser {
 
   static onPortConnection(cb) {
     chrome.runtime.onConnect.addListener(cb);
+  } // A MV3 service worker is evicted after ~30s idle. The popup port only
+  // keeps it alive while the popup is open, but the popup closes as soon as
+  // it loses focus — so a long publish (e.g. "Fetching Images") can outlive
+  // the worker and stall. Pinging an extension API under the idle limit
+  // resets the timer, keeping the worker alive for the whole publish.
+
+
+  static keepAlive() {
+    if (Browser.keepAliveInterval) {
+      return;
+    }
+
+    Browser.keepAliveInterval = setInterval(() => {
+      chrome.runtime.getPlatformInfo(() => {});
+    }, Browser.KEEP_ALIVE_INTERVAL);
+  }
+
+  static stopKeepAlive() {
+    if (Browser.keepAliveInterval) {
+      clearInterval(Browser.keepAliveInterval);
+      Browser.keepAliveInterval = null;
+    }
   }
 
   static download(params) {
@@ -267,6 +297,9 @@ class Browser {
   }
 
 }
+
+Browser.keepAliveInterval = null;
+Browser.KEEP_ALIVE_INTERVAL = 20000; // ping under the ~30s service worker idle limit
 
 Browser.ERROR_CODES = {
   // Book Create Errors
@@ -12109,6 +12142,7 @@ _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].onPortConnection(() => 
 epub_press_js__WEBPACK_IMPORTED_MODULE_0__[/* default */ "a"].BASE_API = `${manifest.homepage_url}api/v1`;
 
 function timeoutDownload() {
+  _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].stopKeepAlive();
   _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].setLocalStorage({
     downloadState: false,
     publishStatus: '{}'
@@ -12122,6 +12156,7 @@ function timeoutDownload() {
 
 _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].onForegroundMessage(request => {
   if (request.action === 'download') {
+    _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].keepAlive();
     _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].setLocalStorage({
       downloadState: true,
       publishStatus: '{}'
@@ -12150,6 +12185,7 @@ _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].onForegroundMessage(req
         });
       }).then(() => {
         clearTimeout(timeout);
+        _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].stopKeepAlive();
         _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].setLocalStorage({
           downloadState: false,
           publishStatus: '{}'
@@ -12160,6 +12196,7 @@ _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].onForegroundMessage(req
         });
       }).catch(e => {
         clearTimeout(timeout);
+        _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].stopKeepAlive();
         _browser__WEBPACK_IMPORTED_MODULE_1__[/* default */ "a"].setLocalStorage({
           downloadState: false,
           publishStatus: '{}'

--- a/packages/epub-press-chrome/app/build/popup.js
+++ b/packages/epub-press-chrome/app/build/popup.js
@@ -192,7 +192,15 @@ class Browser {
   }
 
   static sendMessage(...args) {
-    chrome.runtime.sendMessage(...args);
+    // In MV3 sendMessage returns a promise that rejects with "Receiving
+    // end does not exist" when no popup is open. These are best-effort UI
+    // updates (the popup restores state from storage on reopen), so the
+    // rejection is expected and safe to ignore.
+    const result = chrome.runtime.sendMessage(...args);
+
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
   }
 
   static onBackgroundMessage(cb) {
@@ -219,6 +227,28 @@ class Browser {
 
   static onPortConnection(cb) {
     chrome.runtime.onConnect.addListener(cb);
+  } // A MV3 service worker is evicted after ~30s idle. The popup port only
+  // keeps it alive while the popup is open, but the popup closes as soon as
+  // it loses focus — so a long publish (e.g. "Fetching Images") can outlive
+  // the worker and stall. Pinging an extension API under the idle limit
+  // resets the timer, keeping the worker alive for the whole publish.
+
+
+  static keepAlive() {
+    if (Browser.keepAliveInterval) {
+      return;
+    }
+
+    Browser.keepAliveInterval = setInterval(() => {
+      chrome.runtime.getPlatformInfo(() => {});
+    }, Browser.KEEP_ALIVE_INTERVAL);
+  }
+
+  static stopKeepAlive() {
+    if (Browser.keepAliveInterval) {
+      clearInterval(Browser.keepAliveInterval);
+      Browser.keepAliveInterval = null;
+    }
   }
 
   static download(params) {
@@ -267,6 +297,9 @@ class Browser {
   }
 
 }
+
+Browser.keepAliveInterval = null;
+Browser.KEEP_ALIVE_INTERVAL = 20000; // ping under the ~30s service worker idle limit
 
 Browser.ERROR_CODES = {
   // Book Create Errors

--- a/packages/epub-press-chrome/app/manifest.json
+++ b/packages/epub-press-chrome/app/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_appName__",
     "short_name": "__MSG_appShortName__",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "author": "Harold Treen",
     "homepage_url": "https://epub.press/",
     "manifest_version": 3,

--- a/packages/epub-press-chrome/scripts/background.js
+++ b/packages/epub-press-chrome/scripts/background.js
@@ -10,6 +10,7 @@ Browser.onPortConnection(() => {});
 EpubPress.BASE_API = `${manifest.homepage_url}api/v1`;
 
 function timeoutDownload() {
+    Browser.stopKeepAlive();
     Browser.setLocalStorage({ downloadState: false, publishStatus: '{}' });
     Browser.sendMessage({
         action: 'download',
@@ -20,6 +21,7 @@ function timeoutDownload() {
 
 Browser.onForegroundMessage((request) => {
     if (request.action === 'download') {
+        Browser.keepAlive();
         Browser.setLocalStorage({ downloadState: true, publishStatus: '{}' });
         const timeout = setTimeout(timeoutDownload, DOWNLOAD_TIMEOUT);
 
@@ -46,11 +48,13 @@ Browser.onForegroundMessage((request) => {
                 })
                 .then(() => {
                     clearTimeout(timeout);
+                    Browser.stopKeepAlive();
                     Browser.setLocalStorage({ downloadState: false, publishStatus: '{}' });
                     Browser.sendMessage({ action: 'download', status: 'complete' });
                 })
                 .catch((e) => {
                     clearTimeout(timeout);
+                    Browser.stopKeepAlive();
                     Browser.setLocalStorage({ downloadState: false, publishStatus: '{}' });
                     Browser.sendMessage({ action: 'download', status: 'failed', error: e.message });
                 });

--- a/packages/epub-press-chrome/scripts/browser.js
+++ b/packages/epub-press-chrome/scripts/browser.js
@@ -92,7 +92,14 @@ class Browser {
     }
 
     static sendMessage(...args) {
-        chrome.runtime.sendMessage(...args);
+        // In MV3 sendMessage returns a promise that rejects with "Receiving
+        // end does not exist" when no popup is open. These are best-effort UI
+        // updates (the popup restores state from storage on reopen), so the
+        // rejection is expected and safe to ignore.
+        const result = chrome.runtime.sendMessage(...args);
+        if (result && typeof result.catch === 'function') {
+            result.catch(() => {});
+        }
     }
 
     static onBackgroundMessage(cb) {
@@ -117,6 +124,27 @@ class Browser {
 
     static onPortConnection(cb) {
         chrome.runtime.onConnect.addListener(cb);
+    }
+
+    // A MV3 service worker is evicted after ~30s idle. The popup port only
+    // keeps it alive while the popup is open, but the popup closes as soon as
+    // it loses focus — so a long publish (e.g. "Fetching Images") can outlive
+    // the worker and stall. Pinging an extension API under the idle limit
+    // resets the timer, keeping the worker alive for the whole publish.
+    static keepAlive() {
+        if (Browser.keepAliveInterval) {
+            return;
+        }
+        Browser.keepAliveInterval = setInterval(() => {
+            chrome.runtime.getPlatformInfo(() => {});
+        }, Browser.KEEP_ALIVE_INTERVAL);
+    }
+
+    static stopKeepAlive() {
+        if (Browser.keepAliveInterval) {
+            clearInterval(Browser.keepAliveInterval);
+            Browser.keepAliveInterval = null;
+        }
     }
 
     static download(params) {
@@ -169,6 +197,9 @@ class Browser {
         return msg;
     }
 }
+
+Browser.keepAliveInterval = null;
+Browser.KEEP_ALIVE_INTERVAL = 20000; // ping under the ~30s service worker idle limit
 
 Browser.ERROR_CODES = {
     // Book Create Errors


### PR DESCRIPTION
## Summary

Follow-up to the 0.13.1 MV3 fixes. Two remaining service-worker issues seen on the published 0.13.1, fixed here as **0.13.2**.

### Publishing stalls on long steps (e.g. "Fetching Images")
0.13.1's keepalive relied on a **popup port**, which only holds the service worker alive while the popup is *open and focused*. Chrome action popups close the instant they lose focus, so a long publish step outlives the worker:

1. Popup opens, publish starts, port keeps the worker alive
2. User clicks away → popup closes → port disconnects
3. Worker is evicted after ~30s idle
4. epub-press-js's `setTimeout` poll loop never resumes → UI stuck on the last status ("Fetching Images")

**Fix:** an active keepalive that runs for the whole publish, independent of the popup. A 20s interval pings `chrome.runtime.getPlatformInfo` (well under the ~30s idle limit), resetting the worker's idle timer. Started when a download begins, cleared in every terminal path (success / failure / timeout).

### `Uncaught (in promise) Error: Could not establish connection. Receiving end does not exist.`
In MV3, `chrome.runtime.sendMessage` returns a **promise** that rejects when no popup is listening. The background's status messages are best-effort UI updates (the popup restores state from `localStorage` on reopen), so the rejection is expected and now swallowed.

## Changes
- `scripts/browser.js` — `keepAlive()` / `stopKeepAlive()` helpers; swallow the no-receiver `sendMessage` rejection
- `scripts/background.js` — start keepalive on download begin, stop it on success / failure / timeout
- `app/manifest.json` — version → 0.13.2
- `CHANGELOG.md` — 0.13.2 entry
- `app/build/*.js` — rebuilt bundles

## Testing
- `npm run build` succeeds; built `background.js` includes the `getPlatformInfo` keepalive and has **0** `createElementNS` references
- Manual: publish progresses past "Fetching Images" to completion with the popup closed

## Note
This is a pragmatic keepalive. A fully robust design would persist the book id and *resume* polling on worker startup (surviving a hard eviction / browser restart), via `chrome.alarms` instead of `setTimeout`. Worth considering if stalls persist, but it's a larger refactor that touches epub-press-js's polling internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)